### PR TITLE
[Leia] make debian sync with internal build and further small parts

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,86 @@
+---
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: DontAlign
+AlignOperands:   true
+AlignTrailingComments: false
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: InlineOnly
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Allman
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     100
+CommentPragmas:  '^ IWYU pragma:'
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 2
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IncludeBlocks: Regroup
+IncludeCategories:
+  - Regex:           '^<[a-z0-9_]+>$'
+    Priority:        3
+  - Regex:           '^<(assert|complex|ctype|errno|fenv|float|inttypes|iso646|limits|locale|math|setjmp|signal|stdalign|stdarg|stdatomic|stdbool|stddef|stdint|stdio|stdlib|stdnoreturn|string|tgmath|threads|time|uchar|wchar|wctype)\.h>$'
+    Priority:        3
+  - Regex:           '^<'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        1
+IncludeIsMainRegex: '$'
+IndentCaseLabels: true
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 2
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60000
+PointerAlignment: Left
+ReflowComments:  false
+SortIncludes:    true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+TabWidth:        8
+UseTab:          Never
+...

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
-# imagedecoder.mpo addon for Kodi
-
-This is a [Kodi](http://kodi.tv) image decoder addon for MPO images.
-
 [![License: GPL-2.0-or-later](https://img.shields.io/badge/License-GPL%20v2+-blue.svg)](LICENSE.md)
 [![Build Status](https://travis-ci.org/xbmc/imagedecoder.mpo.svg?branch=Leia)](https://travis-ci.org/xbmc/imagedecoder.mpo/branches)
 [![Build Status](https://dev.azure.com/teamkodi/binary-addons/_apis/build/status/xbmc.imagedecoder.mpo?branchName=Leia)](https://dev.azure.com/teamkodi/binary-addons/_build/latest?definitionId=27&branchName=Leia)
 [![Build Status](https://jenkins.kodi.tv/view/Addons/job/xbmc/job/imagedecoder.mpo/job/Leia/badge/icon)](https://jenkins.kodi.tv/blue/organizations/jenkins/xbmc%2Fimagedecoder.mpo/branches/)
+
+# imagedecoder.mpo addon for Kodi
+
+This is a [Kodi](http://kodi.tv) image decoder addon for MPO images.
+
+An addon to decode MPO (multiple picture object) files. These are used mainly for 3D cameras and the Nintendo 3DS.
 
 ## Build instructions
 

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: kodi-imagedecoder-mpo
 Priority: extra
 Maintainer: Nobody <nobody@kodi.tv>
 Build-Depends: debhelper (>= 9.0.0), cmake,
-               kodi-addon-dev, libjpeg-dev
+               kodi-addon-dev, libturbojpeg0-dev
 Standards-Version: 4.1.2
 Section: libs
 Homepage: http://kodi.tv

--- a/imagedecoder.mpo/addon.xml.in
+++ b/imagedecoder.mpo/addon.xml.in
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="imagedecoder.mpo"
-  version="1.1.1"
+  version="1.1.2"
   name="MPO image decoder"
   provider-name="spiff">
   <requires>@ADDON_DEPENDS@</requires>

--- a/imagedecoder.mpo/addon.xml.in
+++ b/imagedecoder.mpo/addon.xml.in
@@ -12,7 +12,9 @@
     mimetype="image/mpo"/>
   <extension point="xbmc.addon.metadata">
     <summary lang="en_GB">Multi Picture Object (MPO) image decoder</summary>
+    <summary lang="de_DE">Multi Picture Object (MPO) Bilddekodierer</summary>
     <description lang="en_GB">An addon to decode MPO (multiple picture object) files. These are used mainly for 3D cameras and the Nintendo 3DS.</description>
+    <description lang="de_DE">Ein Addon zum Dekodieren von MPO-Dateien (Multiple Picture Object). Diese werden hauptsächlich für 3D-Kameras und den Nintendo 3DS verwendet.</description>
     <platform>@PLATFORM@</platform>
     <license>GPL-2.0-or-later</license>
     <source>https://github.com/xbmc/imagedecoder.mpo</source>

--- a/src/MPOPicture.cpp
+++ b/src/MPOPicture.cpp
@@ -6,9 +6,10 @@
  *  See LICENSE.md for more information.
  */
 
-#include <kodi/addon-instance/ImageDecoder.h>
 #include <iostream>
-extern "C" {
+#include <kodi/addon-instance/ImageDecoder.h>
+extern "C"
+{
 #include "../lib/libmpo/include/libmpo/dmpo.h"
 }
 
@@ -27,11 +28,14 @@ public:
     m_allocated = false;
   }
 
-  bool LoadImageFromMemory(unsigned char* buffer, unsigned int bufSize, unsigned int& width, unsigned int& height) override
+  bool LoadImageFromMemory(unsigned char* buffer,
+                           unsigned int bufSize,
+                           unsigned int& width,
+                           unsigned int& height) override
   {
     // make a copy of data as we need it at decode time.
     m_data.resize(bufSize);
-    std::copy(buffer, buffer+bufSize, m_data.begin());
+    std::copy(buffer, buffer + bufSize, m_data.begin());
     mpo_create_decompress(&m_mpoinfo);
     mpo_mem_src(&m_mpoinfo, m_data.data(), m_data.size());
     if (!mpo_read_header(&m_mpoinfo))
@@ -41,30 +45,37 @@ public:
     }
     m_allocated = true;
     m_images = mpo_get_number_images(&m_mpoinfo);
-    m_width = width = m_mpoinfo.cinfo.cinfo.image_width*m_images;
+    m_width = width = m_mpoinfo.cinfo.cinfo.image_width * m_images;
     m_height = height = m_mpoinfo.cinfo.cinfo.image_height;
 
     return true;
   }
 
-  bool Decode(unsigned char *pixels,
-                      unsigned int width, unsigned int height,
-                      unsigned int pitch, ImageFormat format) override
+  bool Decode(unsigned char* pixels,
+              unsigned int width,
+              unsigned int height,
+              unsigned int pitch,
+              ImageFormat format) override
   {
     size_t image = 0;
-    while (image < m_images) {
+    while (image < m_images)
+    {
       mpo_start_decompress(&m_mpoinfo);
       JSAMPARRAY buffer;
       int row_stride = m_mpoinfo.cinfo.cinfo.output_width * m_mpoinfo.cinfo.cinfo.output_components;
       size_t lines = 0;
-      while (lines < m_height) {
-        buffer = (*m_mpoinfo.cinfo.cinfo.mem->alloc_sarray)((j_common_ptr)&m_mpoinfo.cinfo, JPOOL_IMAGE, row_stride, m_height);
-        size_t nl = mpo_read_scanlines(&m_mpoinfo,buffer,m_height-lines);
-        for (size_t line = 0; line < nl; ++line) {
-          unsigned char* dst = pixels + (line+lines)*pitch + image*m_width/2*4;
-          for (size_t i = 0; i < row_stride; i += 3) {
-            *dst++ = buffer[line][i+2];
-            *dst++ = buffer[line][i+1];
+      while (lines < m_height)
+      {
+        buffer = (*m_mpoinfo.cinfo.cinfo.mem->alloc_sarray)((j_common_ptr)&m_mpoinfo.cinfo,
+                                                            JPOOL_IMAGE, row_stride, m_height);
+        size_t nl = mpo_read_scanlines(&m_mpoinfo, buffer, m_height - lines);
+        for (size_t line = 0; line < nl; ++line)
+        {
+          unsigned char* dst = pixels + (line + lines) * pitch + image * m_width / 2 * 4;
+          for (size_t i = 0; i < row_stride; i += 3)
+          {
+            *dst++ = buffer[line][i + 2];
+            *dst++ = buffer[line][i + 1];
             *dst++ = buffer[line][i];
             if (format == ADDON_IMG_FMT_A8R8G8B8)
               *dst++ = 0xff;
@@ -92,7 +103,10 @@ class ATTRIBUTE_HIDDEN CMyAddon : public kodi::addon::CAddonBase
 {
 public:
   CMyAddon() = default;
-  ADDON_STATUS CreateInstance(int instanceType, std::string instanceID, KODI_HANDLE instance, KODI_HANDLE& addonInstance) override
+  ADDON_STATUS CreateInstance(int instanceType,
+                              std::string instanceID,
+                              KODI_HANDLE instance,
+                              KODI_HANDLE& addonInstance) override
   {
     addonInstance = new MPOPicture(instance);
     return ADDON_STATUS_OK;


### PR DESCRIPTION
Before was "libjpeg-dev" used, but the internal build by depends take libturbojpeg, this change debian depend to match them too.

Also to have not alone is following added:
- clang format code cleanup (equal to Kodi, only include flow for all <...> alphapetical)
- Add addon description on README.md (taken from addon.xml)
- Show status badges first on README.md (looks better)
- Add german translation (as addon currently not handled by transifex)